### PR TITLE
Pie chart areas normalized and chart labels shortened for easier viewing

### DIFF
--- a/app/activity_plot.R
+++ b/app/activity_plot.R
@@ -78,7 +78,8 @@ Fig_all.plotly <- plot_ly() %>%
                    showline = TRUE),
       legend = list(x = 0, y = 1, traceorder = "normal"),
       font = list(family = "Noto Sans"),
-      showlegend = TRUE
+      showlegend = TRUE,
+      margin = list(t = 50)
     )
   
   # Print the plotly plot

--- a/app/age_plot.R
+++ b/app/age_plot.R
@@ -22,7 +22,8 @@ library(plotly)
   plot <- plot %>% layout(title = list(text = c("Self Reported Ages of Verified Participants")),
                           xaxis = list(title = list(text = "Age")),
                           yaxis = list(title = list(text = "Count")),
-                          font = list(family = "Noto Sans"))
+                          font = list(family = "Noto Sans"),
+                          margin = list(t = 50))
   plot} else{
     # Create the histogram plot with plotly
     plot <- plot_ly(data = age_data, x = ~Age, type = 'histogram',
@@ -34,7 +35,8 @@ library(plotly)
     plot <- plot %>% layout(title = list(text = c("Self Reported Ages of Participants")),
                             xaxis = list(title = list(text = "Age")),
                             yaxis = list(title = list(text = "Count")),
-                            font = list(family = "Noto Sans"))
+                            font = list(family = "Noto Sans"),
+                            margin = list(t = 50))
     plot
     
   }

--- a/app/app.R
+++ b/app/app.R
@@ -25,8 +25,8 @@ server <- function(input, output, session){
   #call data once for entire dashboard
   #authentication step for Posit
   #this code was written by D Russ
-#    source("./get_authentication.R", local = TRUE)
-#    get_authentication(service_account_key = "SERVICE_ACCT_KEY")
+    source("./get_authentication.R", local = TRUE)
+    get_authentication(service_account_key = "SERVICE_ACCT_KEY")
 
 #load verified data
 verified_data <- reactive({
@@ -132,7 +132,7 @@ filtered_IP_data <- reactive({
                   column(4,
                          box(solidHeader = FALSE, title = "Choose Filters:", width = 12,
                              selectInput("siteFilter", "Site",
-                                         choices = c("All Hospitals" = ".",
+                                         choices = c("All" = ".",
                                                      "HealthPartners" = 531629870,
                                                      "Henry Ford Health System" = 548392715,
                                                      "Kaiser Permanente Colorado" = 125001209,
@@ -144,7 +144,7 @@ filtered_IP_data <- reactive({
                                                      "University of Chicago Medicine" = 809703864,
                                                      "National Cancer Institute" = 517700004,
                                                      "National Cancer Institute" = 13, "Other" = 181769837),
-                                         selected = "All Hospitals"),
+                                         selected = "All"),
                              selectInput("sexFilter", "Gender",
                                          choices = c("All" = ".",
                                                      "Male" = "Male",
@@ -261,7 +261,7 @@ filtered_IP_data <- reactive({
                                                              "NA" = "NA"),
                                                  selected = "All"),
                                      selectInput("IPsiteFilter", "Choose Site:",
-                                                 choices = c("All Hospitals" = ".",
+                                                 choices = c("All" = ".",
                                                              "HealthPartners" = 531629870,
                                                              "Henry Ford Health System" = 548392715,
                                                              "Kaiser Permanente Colorado" = 125001209,
@@ -273,7 +273,7 @@ filtered_IP_data <- reactive({
                                                              "University of Chicago Medicine" = 809703864,
                                                              "National Cancer Institute" = 517700004,
                                                              "National Cancer Institute" = 13, "Other" = 181769837),
-                                                 selected = "All Hospitals"),
+                                                 selected = "All"),
                                      actionButton("applyIPfilters", "Apply Filters"))),
                         column(8,
                                fluidRow(

--- a/app/biospecimen_collection_distribution.R
+++ b/app/biospecimen_collection_distribution.R
@@ -18,8 +18,10 @@ names(biocol_counts) <- c("CollectionType", "Count")
   
 # Create a Plotly pie chart
 fig <- plot_ly(biocol_counts, labels = ~CollectionType, values = ~Count, type = 'pie',
-                 textinfo = 'label+percent',
-                 insidetextorientation = 'radial')
+               textinfo='label',
+               hoverinfo = 'label+percent',
+               insidetextorientation = 'radial',
+               domain = list(x = c(0.1, 0.9), y = c(0.1, 0.9)))
   
 # Customize the layout
 curr.date <- Sys.Date()
@@ -39,7 +41,8 @@ fig <- fig %>% layout(
     showticklabels = FALSE
   ),
   showlegend = TRUE,
-  font = list(family = "Noto Sans")
+  font = list(family = "Noto Sans"),
+  margin = list(t = 50)
 )
   
   # Print the plot

--- a/app/completed_survey.R
+++ b/app/completed_survey.R
@@ -21,8 +21,10 @@ names(msrv_df) <- c("Msrv_complt", "Count")
     
 # Create a Plotly pie chart
 fig <- plot_ly(msrv_df, labels = ~Msrv_complt, values = ~Count, type = 'pie',
-                   textinfo = 'label+percent',
-                   insidetextorientation = 'radial')
+               hoverinfo = 'label+percent',
+               textinfo ='label',
+               insidetextorientation = 'radial',
+               domain = list(x = c(0.1, 0.9), y = c(0.1, 0.9)))
     
 # Customize the layout
 curr.date <- Sys.Date()
@@ -33,7 +35,8 @@ fig <- fig %>% layout(title = c("Survey Completion Status"),
                             xanchor = 'left', align = 'left')),
                           xaxis = list(showgrid = FALSE, zeroline = FALSE, showticklabels = FALSE),
                           yaxis = list(showgrid = FALSE, zeroline = FALSE, showticklabels = FALSE),
-                          font = list(family = "Noto Sans"))
+                          font = list(family = "Noto Sans"),
+                           margin = list(t = 50))
     
     # Print the plot
     fig

--- a/app/income_distribution.R
+++ b/app/income_distribution.R
@@ -25,7 +25,8 @@ income_distribution <- income_data %>%
   plot <- plot %>% layout(title = list(text = c("Self Reported Income of Verified Participants")),
                           xaxis = list(title = list(text = "Income")),
                           yaxis = list(title = list(text = "Count")),
-                          font = list(family = "Noto Sans"))
+                          font = list(family = "Noto Sans"),
+                          margin = list(t = 50))
   plot
 
 }

--- a/app/race_plot.R
+++ b/app/race_plot.R
@@ -21,15 +21,17 @@ names(race_df) <- c("race", "Count")
   
 # Create a Plotly pie chart
 fig <- plot_ly(race_df, labels = ~race, values = ~Count, type = 'pie',
-                 textinfo = 'label+percent',
-                 insidetextorientation = 'radial')
+               textinfo='label',
+               hoverinfo = 'label+percent',
+               insidetextorientation = 'radial',
+               domain = list(x = c(0.1, 0.9), y = c(0.1, 0.9)))
   
 # Customize the layout
 curr.date <- Sys.Date()
 fig <- fig %>% layout(title = c("Self-Reported Race of Participants Who Completed BOH Section"),
-                        xaxis = list(showgrid = FALSE, zeroline = FALSE, showticklabels = FALSE),
-                        yaxis = list(showgrid = FALSE, zeroline = FALSE, showticklabels = FALSE),
-                        font = list(family = "Noto Sans"),
+                      xaxis = list(showgrid = FALSE, zeroline = FALSE, showticklabels = FALSE),
+                      yaxis = list(showgrid = FALSE, zeroline = FALSE, showticklabels = FALSE),
+                      font = list(family = "Noto Sans"),
                       margin = list(t = 50))
   
   # Print the plot

--- a/app/rsconnect/appshare-dev.cancer.gov/rebecca.sansale@nih.gov/stakeholder_dashboard.dcf
+++ b/app/rsconnect/appshare-dev.cancer.gov/rebecca.sansale@nih.gov/stakeholder_dashboard.dcf
@@ -5,7 +5,7 @@ account: rebecca.sansale@nih.gov
 server: appshare-dev.cancer.gov
 hostUrl: https://appshare-dev.cancer.gov/__api__
 appId: 67
-bundleId: 359
+bundleId: 362
 url: https://appshare-dev.cancer.gov/content/151bbace-be73-4552-b569-e374e9aafca1/
 version: 1
 asMultiple: FALSE

--- a/app/sex_distribution.R
+++ b/app/sex_distribution.R
@@ -26,6 +26,7 @@ names(sex_df) <- c("sex", "Count")
 fig <- plot_ly(sex_df, labels = ~c("Female", "Nonbinary", "Male"), values = ~Count, type = 'pie',
                  textinfo = 'label+percent',
                  insidetextorientation = 'radial',
+                 domain = list(x = c(0.1, 0.9), y = c(0.1, 0.9)),
                 marker = list(colors = c('rgb(42, 114, 165)', 'rgb(28, 94, 134)', 'rgb(49, 159, 190)'))) # Use the specified colors
   
 # Customize the layout
@@ -33,7 +34,8 @@ curr.date <- Sys.Date()
 fig <- fig %>% layout(title = c("Site Reported Sex of Participants"),
                         xaxis = list(showgrid = FALSE, zeroline = FALSE, showticklabels = FALSE),
                         yaxis = list(showgrid = FALSE, zeroline = FALSE, showticklabels = FALSE),
-                      font = list(family = "Noto Sans"))
+                      font = list(family = "Noto Sans"),
+                      margin = list(t = 50))
   
   # Print the plot
   fig


### PR DESCRIPTION
The areas of the pie charts have been normalized and the chart labels now only show the variable label. Together, these changes reduce the probability of pie chart labels being cut off. Additionally, a top margin of 50 pixels was hard coded into each plot to ensure proper spacing between the plot title and the chart.